### PR TITLE
build with OpenSSL 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documenter: Susan Potter (@mbbx6spp on GH)
 
 Before building this project on Ubuntu (tested on 11.10) you will need to install the following packages:
 
-    [sudo] apt-get install libapt-pkg-dev libcurl4-openssl-dev
+    [sudo] apt-get install build-essential libapt-pkg-dev libcurl4-openssl-dev libssl-dev
 
 To build this project you simply run `make`. It will produce a binary named `s3` under the `src/` dir.
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Jorge A Gallegos <kad@blegh.net>
 Homepage: https://github.com/kyleshank/apt-s3
 Standards-Version: 3.7.3
-Build-Depends: debhelper (>= 5.0), libapt-pkg-dev (>= 0.7.23), cdbs, libcurl4-openssl-dev
+Build-Depends: debhelper (>= 5.0), libapt-pkg-dev (>= 0.7.23), cdbs, libcurl4-openssl-dev, libssl1.1
 
 Package: apt-transport-s3
 Architecture: any

--- a/src/s3.cc
+++ b/src/s3.cc
@@ -822,7 +822,13 @@ void HttpMethod::SendReq(FetchItem *Itm,CircleBuf &Out)
 }
 
 void doEncrypt(char *kString, char *sigString, const char* secretKey){
+    #if OPENSSL_VERSION_NUMBER < 0x10100000L
+	// OpenSSL < 1.1.0
 	HMAC_CTX hctx;
+    #else
+	// OpenSSL >= 1.1.0
+	HMAC_CTX *hctx = HMAC_CTX_new();
+    #endif
 	BIO *bio, *b64;
 	char *sigptr;
 	long siglen = -1;
@@ -832,8 +838,15 @@ void doEncrypt(char *kString, char *sigString, const char* secretKey){
 
 	// Initialize SHA1 encryption
 	sprintf(skey, "%s", secretKey);
+
+	#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	// OpenSSL < 1.1.0
 	HMAC_CTX_init(&hctx);
 	HMAC_Init(&hctx, skey, (int)strlen((char *)skey), EVP_sha1());
+	#else
+	// OpenSSL >= 1.1.0
+	HMAC_Init_ex(hctx, skey, (int)strlen((char *)skey), EVP_sha1(), NULL);
+	#endif
 
 	// Encrypt
 	HMAC(EVP_sha1(), skey, (int)strlen((char *)skey), (unsigned char *)kString,
@@ -853,7 +866,14 @@ void doEncrypt(char *kString, char *sigString, const char* secretKey){
 
 	// Clean up Encryption, Encoding
 	BIO_free_all(bio);
+
+	#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	// OpenSSL < 1.1.0
 	HMAC_CTX_cleanup(&hctx);
+	#else
+	// OpenSSL >= 1.1.0
+	HMAC_CTX_free(hctx);
+	#endif
 }
 									/*}}}*/
 // HttpMethod::Go - Run a single loop					/*{{{*/


### PR DESCRIPTION
The upcoming Ubuntu 18.04 "Bionic Beaver" release ships with OpenSSL 1.1.0g, which is not backwards compatible.